### PR TITLE
Add directions to README for pathogen.vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # .dotfiles
+
+Install Pathogen.vim
+```
+mkdir -p ~/.vim/autoload ~/.vim/bundle && \
+curl -LSso ~/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim
+```


### PR DESCRIPTION
## Problem
Pathogen, when added to the `.vimrc` file, needs to be installed from the command line.

## Solution
Add those directions to the README.